### PR TITLE
Use closures

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,10 @@ Add to your code,
     extern crate logwatcher;
     use logwatcher::LogWatcher;
 
-Create a callback function, which accepts String as input
-
-    fn parse_line(line: String) {
-        println!("Line {}", line);
-    }
-
-Register the logwatcher and watch it!
+Register the logwatcher, pass a closure and watch it!
 
     let mut log_watcher = LogWatcher::register("/var/log/check.log".to_string()).unwrap();
-    log_watcher.watch(parse_line);
 
+    log_watcher.watch(&|line: String| {
+        println!("Line {}", line);
+    });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,13 +22,13 @@ impl LogWatcher {
             Ok(x) => x,
             Err(err) => return Err(err)
         };
-        
+
         let metadata = match f.metadata() {
             Ok(x) => x,
             Err(err) => return Err(err)
         };
 
-        let mut reader = BufReader::new(f);        
+        let mut reader = BufReader::new(f);
         let pos = metadata.len();
         reader.seek(SeekFrom::Start(pos)).unwrap();
         Ok(LogWatcher{filename: filename,
@@ -38,7 +38,8 @@ impl LogWatcher {
                       finish: false})
     }
 
-    fn reopen_if_log_rotated(&mut self, callback: fn (line: String)){
+    fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &F)
+        where F: Fn(String) {
         loop {
             match File::open(self.filename.clone()) {
                 Ok(x) => {
@@ -74,7 +75,8 @@ impl LogWatcher {
         }
     }
 
-    pub fn watch(&mut self, callback: fn (line: String)) {
+    pub fn watch<F: ?Sized>(&mut self, callback: &F)
+        where F: Fn(String) {
         loop{
             let mut line = String::new();
             let resp = self.reader.read_line(&mut line);
@@ -101,9 +103,4 @@ impl LogWatcher {
             }
         }
     }
-}
-
-
-#[test]
-fn it_works() {
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,6 @@ use std::process::exit;
 extern crate logwatcher;
 use logwatcher::LogWatcher;
 
-
-fn parse_line(line: String) {
-    println!("Line {}", line);
-}
-
 fn main(){
     let filename = match args().nth(1) {
         Some(x) => x,
@@ -17,6 +12,10 @@ fn main(){
             exit(1);
         }
     };
+
     let mut log_watcher = LogWatcher::register(filename).unwrap();
-    log_watcher.watch(parse_line);
+
+    log_watcher.watch(&|line: String| {
+        println!("Line {}", line);
+    });
 }


### PR DESCRIPTION
Hey,

as part of a new module I'm building for catapult (a rust "replacement" for logstash) I need to have a closure that is able to access the function context, which is not possible with primitive function pointers.

Problem (1):

	impl SomeTrait for SomeStruct {
		fn foobar (&self, tx: SyncSender<String>) {
			let mut log_watcher = LogWatcher::register("/tmp/foo").unwrap();

			fn foo (line: String) {
				// doesn't work
				tx.send(line);
			}

			log_watcher.watch(foo);
		}
	}

Problem (2):

	impl SomeTrait for SomeStruct {
		fn foobar (&self, tx: SyncSender<String>) {
			let mut log_watcher = LogWatcher::register("/tmp/foo").unwrap();

			log_watcher.watch(&self.ingest);
		}

		fn ingest (line: String) {
			// needless allocation, I'd have to put tx
			// into the struct, forcing me to instanciate
			// a new instance per tx
			self.tx.send(line);
		}
	}

Solution:

	impl SomeTrait for SomeStruct {
		fn foobar (tx: SyncSender<String>) {
			let mut log_watcher = LogWatcher::register("/tmp/foo").unwrap();

			// passing a reference of the closure
			// to retain ownership of it
			log_watcher.watch(&|line: String| {
				tx.send(line);
			});
		}
	}

Yay.

🍻 