### PR TITLE
Change closure from Fn to FnMut.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "logwatcher"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Aravinda VK <mail@aravindavk.in>"]
 
 description = "A lib to watch log files for new Changes, just like tail -f"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,9 +40,9 @@ impl LogWatcher {
         })
     }
 
-    fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &F)
+    fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &mut F)
     where
-        F: Fn(String),
+        F: FnMut(String),
     {
         loop {
             match File::open(self.filename.clone()) {
@@ -78,9 +78,9 @@ impl LogWatcher {
         }
     }
 
-    pub fn watch<F: ?Sized>(&mut self, callback: &F)
+    pub fn watch<F: ?Sized>(&mut self, callback: &mut F)
     where
-        F: Fn(String),
+        F: FnMut(String),
     {
         loop {
             let mut line = String::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,9 @@ impl LogWatcher {
             finish: false,
         })
     }
+    pub fn force_reopen(&mut self) {
+        self.finish = true;
+    }
 
     fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &mut F)
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,8 @@ impl LogWatcher {
                       finish: false})
     }
 
-    fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &F)
-        where F: Fn(String) {
+    fn reopen_if_log_rotated<F: ?Sized>(&mut self, callback: &mut F)
+        where F: FnMut(String) {
         loop {
             match File::open(self.filename.clone()) {
                 Ok(x) => {
@@ -75,8 +75,8 @@ impl LogWatcher {
         }
     }
 
-    pub fn watch<F: ?Sized>(&mut self, callback: &F)
-        where F: Fn(String) {
+    pub fn watch<F: ?Sized>(&mut self, callback: &mut F)
+        where F: FnMut(String) {
         loop{
             let mut line = String::new();
             let resp = self.reader.read_line(&mut line);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::env::args;
 use std::process::exit;
 
 extern crate logwatcher;
-use logwatcher::LogWatcher;
+use logwatcher::{LogWatcher, LogWatcherAction};
 
 fn main() {
     let filename = match args().nth(1) {
@@ -17,5 +17,6 @@ fn main() {
 
     log_watcher.watch(&mut move |line: String| {
         println!("Line {}", line);
+        LogWatcherAction::None
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ fn main() {
 
     let mut log_watcher = LogWatcher::register(filename).unwrap();
 
-    log_watcher.watch(&|line: String| {
+    log_watcher.watch(&mut move |line: String| {
         println!("Line {}", line);
     });
 }


### PR DESCRIPTION
This allows code to use the `move` keyword when passing in a closure to modify values within the closure. Example:
```
fn main() {
    let mut log_watcher = LogWatcher::register("/var/log/check.log".to_string()).unwrap();

    let mut count = 0;
    log_watcher.watch(&mut move |line: String| {
        println!("Count:{}, Line {}", count, line);
        count = count + 1;
    });
}
```