### PR TITLE
Feature position

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ use std::time::Duration;
 pub enum StartFrom {
     /// The beginning of the file
     Beginning,
-    /// Specify the position offset to start from
+    /// Specify the cursor position offset
     Offset(u64),
     /// The end of the file, which is the last known position
     End,
@@ -34,8 +34,8 @@ pub struct LogWatcher {
 
 impl LogWatcher {
     pub fn register<P: AsRef<Path>>(
-        starts_from: StartFrom,
         filename: P,
+        starts_from: StartFrom,
     ) -> Result<LogWatcher, io::Error> {
         let f = match File::open(&filename) {
             Ok(x) => x,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
+extern crate logwatcher;
+
+use logwatcher::{LogWatcher, LogWatcherAction, StartFrom};
 use std::env::args;
 use std::process::exit;
-
-extern crate logwatcher;
-use logwatcher::{LogWatcher, LogWatcherAction};
 
 fn main() {
     let filename = match args().nth(1) {
@@ -13,10 +13,10 @@ fn main() {
         }
     };
 
-    let mut log_watcher = LogWatcher::register(filename).unwrap();
+    let mut log_watcher = LogWatcher::register(StartFrom::End, filename).unwrap();
 
-    log_watcher.watch(&mut move |line: String| {
-        println!("Line {}", line);
+    log_watcher.watch(&mut move |pos: u64, len: usize, line: String| {
+        println!("Pos #{}, len {} char, Line: `{}`", pos, len, line);
         LogWatcherAction::None
     });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ fn main() {
         }
     };
 
-    let mut log_watcher = LogWatcher::register(StartFrom::End, filename).unwrap();
+    let mut log_watcher = LogWatcher::register(filename, StartFrom::End).unwrap();
 
     log_watcher.watch(&mut move |pos: u64, len: usize, line: String| {
         println!("Pos #{}, len {} char, Line: `{}`", pos, len, line);


### PR DESCRIPTION
This new feature helps to start to tail within' the file from a specific location such as:
  - beginning of the file
  - an offset
  - the end of the file (what is being used currently)

This is useful when you'd like to resume the tail from where you've left before. 
I use this feature for this library: https://github.com/dizda/file-trailer which helps to read logfile, then push each lines into an AMQP queue. In case the daemon has been stopped or crashed, it will emit these logs from where it stopped, a la logstash.